### PR TITLE
Updates react-print for performance improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@fileforge/client": "^0.1.13",
-        "@fileforge/react-print": "^0.1.139",
+        "@fileforge/react-print": "^0.1.150",
         "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "react": "^18.3.1",
@@ -108,6 +108,54 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-4.0.8.tgz",
+      "integrity": "sha512-0aj591yGlq5Qac+plaWCbn5cpjs5Sh0daovYUKJUOMjIp70prGH/XPLp7QjxtbFXz3CTvb0H9a35dpEuIuUi3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.1.1",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+      "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -603,10 +651,12 @@
       }
     },
     "node_modules/@fileforge/react-print": {
-      "version": "0.1.139",
-      "resolved": "https://registry.npmjs.org/@fileforge/react-print/-/react-print-0.1.139.tgz",
-      "integrity": "sha512-3H1QXDDM47tOUaaz9GILBrHdR6yF5wgoKf4+sYxSrlFa313v+J1xp5CRBy3T6/6IaRVrI04LoMUicpRo7ICajg==",
+      "version": "0.1.150",
+      "resolved": "https://registry.npmjs.org/@fileforge/react-print/-/react-print-0.1.150.tgz",
+      "integrity": "sha512-mD36MaKM8XwT7XmvtjzTWz0+R+BaY6GrI+rcqR3pMuUpY1Bq+B+25SwmV5ocdBkJXXFtRgbb/jlSyJahjbMITw==",
+      "license": "ISC",
       "dependencies": {
+        "@csstools/postcss-is-pseudo-class": "^4.0.8",
         "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.3",
         "@emotion/server": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@fileforge/client": "^0.1.13",
-    "@fileforge/react-print": "^0.1.139",
+    "@fileforge/react-print": "^0.1.150",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "react": "^18.3.1",


### PR DESCRIPTION
Tried a few different options to make the generation faster, changing the `<Tailwind/>` rendering method upstream did greatly improve the React => HTML process by removing quite a bunch of regex executions.

The HTML => PDF Part is taking about 3 seconds now, which added to the React => HTML make it about 4.

Let me know if this is more in-tune!